### PR TITLE
Fix skipped logs API messages

### DIFF
--- a/logservice/logservice.go
+++ b/logservice/logservice.go
@@ -169,7 +169,7 @@ func (s *LogService) logHandler(w http.ResponseWriter, r *http.Request) {
 		case PlatformReport:
 			// Check if we need to send platform report to forwarders
 			if !s.enablePlatformReport {
-				break
+				continue
 			}
 
 			var reportRecord ReportRecord


### PR DESCRIPTION
If you receive a batch of messages and one of them is a `PlatformReport` then all subsequent messages are discarded due to the `break`.

Ask me how I know ;)